### PR TITLE
chore(pom.xml) update minimized jar support

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -132,7 +132,7 @@
         </executions>
         <configuration>
           <createDependencyReducedPom>true</createDependencyReducedPom>
-          <minimizeJar>true</minimizeJar>
+          <minimizeJar>false</minimizeJar>
           <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,6 @@
             <version>1.0.2</version>
         </dependency>
 
-
     </dependencies>
 
     <build>
@@ -208,7 +207,7 @@
                 <version>${maven.shade.version}</version>
                 <configuration>
                     <createDependencyReducedPom>true</createDependencyReducedPom>
-                    <minimizeJar>true</minimizeJar>
+                    <minimizeJar>false</minimizeJar> <!-- Hibernate dependency on Dropwizard force Java7 support-->
                     <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
                 </configuration>
                 <executions>


### PR DESCRIPTION
- JDK8+ needed for minimized jar conflicts with Java7 support requirement for hibernate dep